### PR TITLE
feat: update Explorer design for Sanity design language

### DIFF
--- a/apps/sdk-explorer/src/App.tsx
+++ b/apps/sdk-explorer/src/App.tsx
@@ -1,18 +1,29 @@
+import {hues} from '@sanity/color'
 import {SanityMonogram} from '@sanity/logos'
 import {Box, Card, Container, Flex, Inline, Text} from '@sanity/ui'
 import {type JSX} from 'react'
 import {BrowserRouter, Link, Route, Routes} from 'react-router'
+import {createGlobalStyle} from 'styled-components'
 
 import DocumentTable from './document-collections/DocumentTable/DocumentTable'
 import PreviewGrid from './document-collections/PreviewGrid/PreviewGrid'
 import PreviewList from './document-collections/PreviewList/PreviewList'
 import MoviesByActor from './groq/MoviesByActor/MoviesByActor'
 import Home from './Home'
+import ScrollOnPathChange from './ScollOnPathChange'
+
+const Body = createGlobalStyle`
+  body {
+    background-color: ${hues.gray['50'].hex};
+  }
+`
 
 export default function App(): JSX.Element {
   return (
     <BrowserRouter>
-      <Card style={{position: 'relative'}}>
+      <Body />
+      <ScrollOnPathChange />
+      <Card style={{position: 'relative'}} tone="transparent">
         <Card
           tone="transparent"
           shadow={1}
@@ -35,11 +46,15 @@ export default function App(): JSX.Element {
                 </Link>
               </Text>
               <Inline space={4}>
-                <Link to="/">
-                  <Text weight="medium" size={1}>
-                    Home
-                  </Text>
-                </Link>
+                <Text weight="medium" size={1}>
+                  <a href="/">Home</a>
+                </Text>
+                <Text weight="medium" size={1}>
+                  <a href="https://sdk-docs.sanity.dev">SDK Docs</a>
+                </Text>
+                <Text weight="medium" size={1}>
+                  <a href="https://github.com/sanity-io/sdk">GitHub</a>
+                </Text>
               </Inline>
             </Flex>
           </Box>

--- a/apps/sdk-explorer/src/ExampleCard.tsx
+++ b/apps/sdk-explorer/src/ExampleCard.tsx
@@ -1,5 +1,5 @@
 import {hues} from '@sanity/color'
-import {Card, Stack, Text} from '@sanity/ui'
+import {Card, Inline, Stack, Text} from '@sanity/ui'
 import {type JSX} from 'react'
 import {Link} from 'react-router'
 
@@ -8,6 +8,7 @@ import ExampleAttributes from './ExampleAttributes'
 interface ExampleCardProps {
   description: string
   hooks: Array<string>
+  img: string
   styling: string
   title: string
   to: string
@@ -20,19 +21,36 @@ export default function ExampleCard({
   title,
   description,
   hooks,
+  img,
   styling,
   to,
 }: ExampleCardProps): JSX.Element {
   return (
     <Link to={to} style={{textDecoration: 'none'}}>
-      <Card tone="neutral" paddingX={3} paddingY={4} radius={3}>
-        <Stack space={4}>
-          <Text as="h3" size={3} weight="medium" style={{color: hues.red['500'].hex}}>
-            {title}
-          </Text>
-          <Text size={1}>{description}</Text>
-          <ExampleAttributes hooks={hooks} styling={styling} />
-        </Stack>
+      <Card shadow={2} paddingX={2} paddingY={3} radius={3}>
+        <Inline space={5}>
+          <div
+            style={{
+              backgroundImage: `url(${img})`,
+              backgroundSize: 'fit',
+              backgroundRepeat: 'no-repeat',
+              maskImage: 'linear-gradient(to bottom right, white, transparent)',
+              maskMode: 'alpha',
+              width: 200,
+              height: 200,
+              display: 'inline-block',
+            }}
+          />
+          <Stack space={4}>
+            <Text as="h3" size={3} weight="medium" style={{color: hues.blue['500'].hex}}>
+              {title}
+            </Text>
+            <Text size={1} muted>
+              {description}
+            </Text>
+            <ExampleAttributes hooks={hooks} styling={styling} />
+          </Stack>
+        </Inline>
       </Card>
     </Link>
   )

--- a/apps/sdk-explorer/src/ExampleLayout.tsx
+++ b/apps/sdk-explorer/src/ExampleLayout.tsx
@@ -1,4 +1,4 @@
-import {Box, Heading, Stack} from '@sanity/ui'
+import {Box, Card, Heading, Stack, Text} from '@sanity/ui'
 import {type JSX} from 'react'
 
 import ExampleAttributes from './ExampleAttributes'
@@ -10,6 +10,7 @@ interface ExampleLayoutProps {
   codeUrl: string
   hooks: Array<string>
   styling: string
+  summary: string
 }
 
 /**
@@ -21,7 +22,9 @@ export default function ExampleLayout({
   codeUrl,
   hooks,
   styling,
+  summary,
 }: ExampleLayoutProps): JSX.Element {
+  // Scroll to top of view when component loads
   return (
     <Stack space={5}>
       <Heading as="h1" size={5} style={{fontWeight: '500'}}>
@@ -29,10 +32,17 @@ export default function ExampleLayout({
       </Heading>
       <ExampleAttributes hooks={hooks} styling={styling} />
       <Box>
+        <Text muted style={{maxInlineSize: '64ch'}}>
+          {summary}
+        </Text>
+      </Box>
+      <Box>
         <ViewCode url={codeUrl} />
       </Box>
       <hr style={{border: 'none', borderTop: '1px solid #ddd'}} />
-      <Box>{children}</Box>
+      <Card padding={4} radius={3} shadow={3}>
+        {children}
+      </Card>
     </Stack>
   )
 }

--- a/apps/sdk-explorer/src/Home.tsx
+++ b/apps/sdk-explorer/src/Home.tsx
@@ -1,7 +1,11 @@
-import {Box, Card, Heading, Stack, Text} from '@sanity/ui'
+import {Box, Heading, Stack, Text} from '@sanity/ui'
 import {type JSX} from 'react'
 
 import ExampleCard from './ExampleCard'
+import DocumentTableImage from './images/DocumentTable.svg'
+import MoviesByActorImage from './images/MoviesByActor.svg'
+import PreviewGridImage from './images/PreviewGrid.svg'
+import PreviewListImage from './images/PreviewList.svg'
 
 export default function Home(): JSX.Element {
   return (
@@ -17,13 +21,13 @@ export default function Home(): JSX.Element {
         >
           SDK Explorer
         </Heading>
-        <Stack space={5}>
-          <Text size={3} muted>
+        <Stack space={5} style={{maxInlineSize: '64ch'}}>
+          <Text size={2} muted>
             The Sanity App SDK Explorer contains an assortment of example interfaces built with our
             React SDK’s hooks. The purpose of the Explorer is to demonstrate how these hooks can be
             used to build out interfaces powered by Sanity, with a variety of approaches to styling.
           </Text>
-          <Text size={3} muted>
+          <Text size={2} muted>
             Each example contains an interface rendered in the browser as well as a link to the
             example’s code on GitHub to demonstrate how the example is built. Example code is
             enriched with comments and may freely be used in your own applications.
@@ -31,58 +35,58 @@ export default function Home(): JSX.Element {
         </Stack>
       </Stack>
 
-      <Stack space={5} paddingY={4}>
-        <Card padding={4} radius={2} shadow={3}>
-          <Stack space={4}>
-            <Text as="h2" size={4} weight="medium">
-              Document collections
-            </Text>
+      <Stack space={6} paddingY={4}>
+        <Stack space={5}>
+          <Text as="h2" size={4} weight="medium">
+            Document collections
+          </Text>
 
-            <Stack space={3}>
-              <ExampleCard
-                to="/document-collections/document-table"
-                title="Document table"
-                description="A tabular rendering of documents and their content"
-                hooks={['usePaginatedList', 'useProjection']}
-                styling="Tailwind"
-              />
-              <ExampleCard
-                to="/document-collections/preview-list"
-                title="Preview list"
-                description="A list of document previews"
-                hooks={['useInfiniteList', 'useProjection']}
-                styling="Sanity UI"
-              />
-              <ExampleCard
-                to="/document-collections/preview-grid"
-                title="Preview grid"
-                description="A grid of document previews"
-                hooks={['useInfiniteList', 'useProjection']}
-                styling="Tailwind"
-              />
-            </Stack>
+          <Stack space={3}>
+            <ExampleCard
+              to="/document-collections/document-table"
+              title="Document table"
+              description="A tabular rendering of documents and their content"
+              hooks={['usePaginatedList', 'useProjection']}
+              styling="Tailwind"
+              img={DocumentTableImage}
+            />
+            <ExampleCard
+              to="/document-collections/preview-list"
+              title="Preview list"
+              description="A list of document previews"
+              hooks={['useInfiniteList', 'useProjection']}
+              styling="Sanity UI"
+              img={PreviewListImage}
+            />
+            <ExampleCard
+              to="/document-collections/preview-grid"
+              title="Preview grid"
+              description="A grid of document previews"
+              hooks={['useInfiniteList', 'useProjection']}
+              styling="Tailwind"
+              img={PreviewGridImage}
+            />
           </Stack>
-        </Card>
+        </Stack>
       </Stack>
 
-      <Stack space={5} paddingY={4}>
-        <Card padding={4} radius={2} shadow={3}>
-          <Stack space={4}>
-            <Text as="h2" size={4} weight="medium">
-              GROQ
-            </Text>
+      <Stack space={6} paddingY={4}>
+        <Stack space={5}>
+          <Text as="h2" size={4} weight="medium">
+            GROQ
+          </Text>
 
-            <Stack space={3}>
-              <ExampleCard
-                to="/groq/movies-by-actor"
-                title="Movies by actor"
-                description="Use multiple useQuery hooks to fetch and filter data"
-                hooks={['useQuery']}
-                styling="Sanity UI"
-              />
-            </Stack>
+          <Stack space={3}>
+            <ExampleCard
+              to="/groq/movies-by-actor"
+              title="Movies by actor"
+              description="Use multiple useQuery hooks to fetch and filter data"
+              hooks={['useQuery']}
+              styling="Sanity UI"
+              img={MoviesByActorImage}
+            />
           </Stack>
-        </Card>
+        </Stack>
       </Stack>
     </Box>
   )

--- a/apps/sdk-explorer/src/ScollOnPathChange.tsx
+++ b/apps/sdk-explorer/src/ScollOnPathChange.tsx
@@ -1,0 +1,12 @@
+import {useEffect} from 'react'
+import {useLocation} from 'react-router'
+
+export default function ScrollOnPathChange(): null {
+  const {pathname} = useLocation()
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [pathname])
+
+  return null
+}

--- a/apps/sdk-explorer/src/ViewCode.tsx
+++ b/apps/sdk-explorer/src/ViewCode.tsx
@@ -10,7 +10,7 @@ export default function ViewCode({url}: {url: string}): JSX.Element {
       as="a"
       href={url}
       target="_blank"
-      mode="ghost"
+      tone="primary"
       text="View the code on GitHub"
       fontSize={2}
       padding={4}

--- a/apps/sdk-explorer/src/document-collections/DocumentTable/DocumentTable.tsx
+++ b/apps/sdk-explorer/src/document-collections/DocumentTable/DocumentTable.tsx
@@ -65,6 +65,7 @@ export default function DocumentTable(): JSX.Element {
       codeUrl="https://github.com/sanity-io/sdk-examples/blob/main/apps/sdk-explorer/src/document-collections/DocumentTable/DocumentTable.tsx"
       hooks={['usePaginatedList', 'useProjection']}
       styling="Tailwind"
+      summary="This example uses the usePaginatedList hook to retrieve a paginated collection of documents with six items per page, in addition to state and functions to control the pagination. The useProjection hook is used to retrieve contents and create projections from each document. Each document and its content and projections are then rendered in a table row."
     >
       <table className="w-full text-sm border-collapse">
         <thead>

--- a/apps/sdk-explorer/src/document-collections/PreviewGrid/PreviewGrid.tsx
+++ b/apps/sdk-explorer/src/document-collections/PreviewGrid/PreviewGrid.tsx
@@ -27,7 +27,6 @@ function DocumentPreview({document}: {document: DocumentHandle}): JSX.Element {
   // plus an `isPending` flag to indicate if projection value resolutions are pending
   const {
     results: {title, cast, posterImage},
-    isPending,
   }: ProjectionResults = useProjection({
     document,
     ref,
@@ -42,9 +41,7 @@ function DocumentPreview({document}: {document: DocumentHandle}): JSX.Element {
     <button
       // Assign the ref to the outer element
       ref={ref}
-      // When preview values are resolving, we’ll lower the opacity to indicate this state visually
       className={`
-        group
         appearance-none
         text-start
         flex
@@ -52,14 +49,14 @@ function DocumentPreview({document}: {document: DocumentHandle}): JSX.Element {
         p-3
         rounded-sm
         bg-gray-100
-        ${isPending ? 'opacity-50' : 'opacity-100'}
+        hover:bg-gray-300
       `}
       onClick={() => alert(`Great pick! ${title} is an excellent movie.`)}
     >
       <img
         alt=""
         src={posterImage}
-        className="aspect-square w-full rounded-sm bg-gray-100 object-cover group-hover:opacity-75 xl:aspect-7/8"
+        className="aspect-square w-full rounded-sm bg-gray-100 object-cover xl:aspect-7/8"
         width="400"
         height="400"
       />
@@ -83,6 +80,7 @@ function PreviewGrid(): JSX.Element {
       codeUrl="https://github.com/sanity-io/sdk-examples/blob/main/apps/sdk-explorer/src/document-collections/PreviewGrid/PreviewGrid.tsx"
       hooks={['useInfiniteList', 'useProjection']}
       styling="Tailwind"
+      summary="This example uses the useInfiniteList hook to retrieve a collection of documents. That collection is then mapped over, with each document passed to a component that uses the useProjection hook to retrieve each document’s title and poster image, and to create a projection of the first three listed cast members. The results are displayed in a grid."
     >
       <div className="grid grid-cols-1 gap-x-4 gap-y-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
         {movies.map((movie) => (

--- a/apps/sdk-explorer/src/document-collections/PreviewList/PreviewList.tsx
+++ b/apps/sdk-explorer/src/document-collections/PreviewList/PreviewList.tsx
@@ -35,7 +35,6 @@ function DocumentPreview({document}: {document: DocumentHandle}) {
   // plus an `isPending` flag to indicate if projection value resolutions are pending
   const {
     results: {title, cast, posterImage},
-    isPending,
   }: ProjectionResults = useProjection({
     document,
     ref,
@@ -52,8 +51,6 @@ function DocumentPreview({document}: {document: DocumentHandle}) {
       ref={ref}
       mode="bleed"
       onClick={() => alert(`Good choice! ${title} is an excellent movie.`)}
-      // When preview values are resolving, we’ll lower the opacity to indicate this state visually
-      style={{opacity: isPending ? 0.5 : 1}}
     >
       <Inline space={4}>
         <img src={posterImage} alt="" width="96" height="144" />
@@ -92,6 +89,7 @@ function PreviewList(): JSX.Element {
       codeUrl="https://github.com/sanity-io/sdk-examples/blob/main/apps/sdk-explorer/src/document-collections/PreviewList/PreviewList.tsx"
       hooks={['useInfiniteList', 'useProjection']}
       styling="Sanity UI"
+      summary="This example uses the useInfiniteList hook to retrieve a collection of documents. That collection is then mapped over, with each document passed to a component that uses the useProjection hook to retrieve each document’s title and poster image, and to create a projection of the first three listed cast members."
     >
       <Stack>
         {movies.map((movie) => (

--- a/apps/sdk-explorer/src/groq/MoviesByActor/MoviesByActor.tsx
+++ b/apps/sdk-explorer/src/groq/MoviesByActor/MoviesByActor.tsx
@@ -53,8 +53,9 @@ export default function MoviesByActor(): JSX.Element {
       codeUrl="https://github.com/sanity-io/sdk-examples/blob/main/apps/sdk-explorer/src/groq/MoviesByActor/MoviesByActor.tsx"
       hooks={['useQuery']}
       styling="Sanity UI"
+      summary="This example uses two instances of the useQuery hook. The first executes a GROQ query to look for entries of type ‘person’ in our dataset and filters those entries down to those who are referenced in at least 2 movie entries’ ‘castMembers’ field. For each of those results, we return a projection that includes the person’s name, photo, and document ID. The second useQuery hook executes a GROQ query for the movies the selected person has starred in, and returns the title, poster image, release date, and document ID for each."
     >
-      <Stack space={5}>
+      <Stack space={4}>
         {/* Render a select element and populate it with an option for each cast member */}
         <Stack space={3}>
           <Label htmlFor="castMembers">Select a cast member:</Label>

--- a/apps/sdk-explorer/src/images/DocumentTable.svg
+++ b/apps/sdk-explorer/src/images/DocumentTable.svg
@@ -1,0 +1,715 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="200" height="200" fill="white"/>
+<mask id="mask0_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="40" width="36" height="36">
+<rect x="10" y="40" width="36" height="36" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -132.438 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -128.74 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -125.041 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -121.342 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -117.644 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -113.945 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -110.247 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -106.548 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -102.849 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -99.1507 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -95.452 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -91.7534 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.0548 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.3561 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -80.6575 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -76.9589 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.2603 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -69.5616 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -65.863 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.1644 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -58.4658 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -54.7671 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.0685 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.3699 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -43.6713 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -39.9726 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.274 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.5753 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -28.8767 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.1781 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.4794 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -17.7808 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.0822 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.3835 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -6.68494 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -2.9863 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.712341 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.41095 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 8.10962 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.8082 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.5068 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.2055 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.9041 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.6028 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.3014 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.6986 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.3972 146)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.0959 146)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask1_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="62" y="54" width="42" height="8">
+<rect x="62" y="54" width="42" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask1_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.3014 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.6027 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.9041 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.2055 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.5068 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.8082 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.1096 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.4109 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.7123 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.0137 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.31506 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.383575 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.08218 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.78082 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.4795 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.1781 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.8767 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.5753 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.274 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.9726 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.6712 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.3699 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.0685 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.7671 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.4658 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.1644 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.863 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.5616 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.2603 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.9589 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.6575 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.3562 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.0548 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.7534 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.4521 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.1507 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.8493 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 96.5479 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.247 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 103.945 157)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask2_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="118" y="54" width="21" height="8">
+<rect x="118" y="54" width="21" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask2_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 12 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.6986 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.3972 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 23.0959 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.7945 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.4932 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34.1918 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.8904 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.5891 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.2877 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.9863 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.6849 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 56.3836 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 60.0822 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.7808 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 67.4795 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 71.1781 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.8767 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.5753 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 82.274 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.9726 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.6712 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 93.3699 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 97.0685 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.767 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 104.466 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 108.164 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 111.863 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 115.562 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 119.26 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 122.959 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 126.658 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 130.356 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 134.055 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 137.753 157)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask3_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="153" y="54" width="21" height="8">
+<rect x="153" y="54" width="21" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask3_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.6986 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.3972 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.0959 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.7945 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.4932 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.1918 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.8904 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.5891 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.2877 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.9863 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.6849 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.3836 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.0822 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.7808 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.479 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.178 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.877 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.575 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.274 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.973 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.671 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 128.37 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 132.068 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.767 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 139.466 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 143.164 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.863 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.562 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 154.26 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.959 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.658 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 165.356 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 169.055 157)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.753 157)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask4_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="96" width="36" height="36">
+<rect x="10" y="96" width="36" height="36" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask4_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -132.438 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -128.74 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -125.041 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -121.342 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -117.644 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -113.945 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -110.247 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -106.548 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -102.849 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -99.1507 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -95.452 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -91.7534 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.0548 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.3561 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -80.6575 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -76.9589 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.2603 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -69.5616 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -65.863 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.1644 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -58.4658 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -54.7671 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.0685 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.3699 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -43.6713 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -39.9726 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.274 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.5753 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -28.8767 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.1781 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.4794 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -17.7808 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.0822 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.3835 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -6.68494 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -2.9863 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.712341 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.41095 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 8.10962 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.8082 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.5068 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.2055 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.9041 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.6028 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.3014 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.6986 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.3972 202)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.0959 202)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask5_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="62" y="110" width="42" height="8">
+<rect x="62" y="110" width="42" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask5_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.3014 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.6027 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.9041 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.2055 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.5068 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.8082 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.1096 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.4109 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.7123 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.0137 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.31506 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.383575 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.08218 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.78082 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.4795 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.1781 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.8767 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.5753 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.274 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.9726 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.6712 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.3699 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.0685 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.7671 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.4658 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.1644 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.863 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.5616 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.2603 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.9589 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.6575 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.3562 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.0548 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.7534 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.4521 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.1507 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.8493 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 96.5479 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.247 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 103.945 213)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask6_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="118" y="110" width="21" height="8">
+<rect x="118" y="110" width="21" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask6_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 12 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.6986 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.3972 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 23.0959 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.7945 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.4932 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34.1918 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.8904 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.5891 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.2877 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.9863 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.6849 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 56.3836 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 60.0822 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.7808 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 67.4795 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 71.1781 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.8767 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.5753 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 82.274 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.9726 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.6712 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 93.3699 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 97.0685 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.767 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 104.466 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 108.164 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 111.863 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 115.562 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 119.26 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 122.959 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 126.658 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 130.356 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 134.055 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 137.753 213)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask7_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="153" y="110" width="21" height="8">
+<rect x="153" y="110" width="21" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask7_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.6986 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.3972 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.0959 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.7945 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.4932 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.1918 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.8904 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.5891 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.2877 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.9863 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.6849 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.3836 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.0822 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.7808 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.479 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.178 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.877 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.575 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.274 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.973 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.671 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 128.37 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 132.068 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.767 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 139.466 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 143.164 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.863 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.562 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 154.26 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.959 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.658 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 165.356 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 169.055 213)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.753 213)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask8_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="152" width="36" height="36">
+<rect x="10" y="152" width="36" height="36" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask8_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -132.438 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -128.74 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -125.041 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -121.342 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -117.644 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -113.945 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -110.247 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -106.548 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -102.849 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -99.1507 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -95.452 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -91.7534 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.0548 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.3561 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -80.6575 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -76.9589 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.2603 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -69.5616 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -65.863 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.1644 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -58.4658 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -54.7671 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.0685 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.3699 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -43.6713 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -39.9726 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.274 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.5753 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -28.8767 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.1781 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.4794 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -17.7808 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.0822 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.3835 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -6.68494 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -2.9863 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.712341 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.41095 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 8.10962 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.8082 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.5068 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.2055 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.9041 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.6028 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.3014 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.6986 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.3972 258)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.0959 258)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask9_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="62" y="166" width="42" height="8">
+<rect x="62" y="166" width="42" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask9_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.3014 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.6027 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.9041 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.2055 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.5068 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.8082 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.1096 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.4109 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.7123 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.0137 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.31506 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.383575 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.08218 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.78082 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.4795 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.1781 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.8767 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.5753 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.274 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.9726 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.6712 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.3699 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.0685 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.7671 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.4658 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.1644 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.863 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.5616 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.2603 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.9589 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.6575 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.3562 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.0548 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.7534 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.4521 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.1507 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.8493 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 96.5479 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.247 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 103.945 269)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask10_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="118" y="166" width="21" height="8">
+<rect x="118" y="166" width="21" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask10_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 12 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.6986 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.3972 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 23.0959 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.7945 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.4932 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34.1918 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.8904 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.5891 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.2877 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.9863 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.6849 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 56.3836 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 60.0822 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.7808 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 67.4795 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 71.1781 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.8767 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.5753 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 82.274 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.9726 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.6712 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 93.3699 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 97.0685 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.767 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 104.466 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 108.164 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 111.863 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 115.562 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 119.26 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 122.959 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 126.658 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 130.356 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 134.055 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 137.753 269)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask11_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="153" y="166" width="21" height="8">
+<rect x="153" y="166" width="21" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask11_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.6986 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.3972 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.0959 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.7945 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.4932 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.1918 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.8904 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.5891 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.2877 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.9863 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.6849 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.3836 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.0822 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.7808 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.479 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.178 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.877 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.575 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.274 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.973 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.671 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 128.37 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 132.068 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.767 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 139.466 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 143.164 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.863 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.562 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 154.26 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.959 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.658 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 165.356 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 169.055 269)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.753 269)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask12_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="12" width="45" height="8">
+<rect x="10" y="12" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask12_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -96 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.3014 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.6027 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.9041 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.2055 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.5068 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.8082 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.1096 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.4109 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.7123 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.0137 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.3151 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.6165 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.9178 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.2192 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.5206 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.8219 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.1233 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.4247 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.726 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.0274 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.3288 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.6301 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.9315 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.23288 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.53424 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.164368 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.86301 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.56165 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.2603 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.9589 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.6575 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.3562 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.0548 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.7534 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.4521 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.1507 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.8493 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.5479 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.2466 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.9452 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask13_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="65" y="12" width="28" height="8">
+<rect x="65" y="12" width="28" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask13_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -41 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -37.3014 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.6027 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.9041 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -26.2055 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.5068 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.8082 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -15.1096 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -11.4109 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.71234 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -4.0137 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -0.315063 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.38358 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.08218 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10.7808 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.4795 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.1781 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.8767 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 25.5753 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.274 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.9726 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 36.6712 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.3699 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.0685 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47.7671 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.4658 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.1644 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.863 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 62.5616 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.2603 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.9589 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 73.6575 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 77.3562 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.0548 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 84.7534 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 88.4521 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.1507 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask14_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="118" y="12" width="18" height="8">
+<rect x="118" y="12" width="18" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask14_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 12 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.6986 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.3972 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 23.0959 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.7945 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.4932 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34.1918 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.8904 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.5891 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.2877 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.9863 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.6849 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 56.3836 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 60.0822 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.7808 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 67.4795 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 71.1781 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.8767 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.5753 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 82.274 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.9726 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.6712 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 93.3699 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 97.0685 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.767 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 104.466 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 108.164 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 111.863 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 115.562 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 119.26 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 122.959 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 126.658 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 130.356 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 134.055 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask15_17_14373" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="153" y="12" width="28" height="8">
+<rect x="153" y="12" width="28" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask15_17_14373)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.6986 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.3972 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.0959 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.7945 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.4932 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.1918 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.8904 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.5891 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.2877 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.9863 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.6849 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.3836 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.0822 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.7808 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.479 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.178 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.877 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.575 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.274 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.973 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.671 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 128.37 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 132.068 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.767 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 139.466 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 143.164 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.863 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.562 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 154.26 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.959 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.658 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 165.356 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 169.055 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.753 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 176.452 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 180.151 115)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<line x1="10.5" y1="29.5" x2="189.5" y2="29.5" stroke="#909BCB" stroke-opacity="0.26" stroke-linecap="round"/>
+<line x1="10.5" y1="85.5" x2="189.5" y2="85.5" stroke="#909BCB" stroke-opacity="0.26" stroke-linecap="round"/>
+<line x1="10.5" y1="141.5" x2="189.5" y2="141.5" stroke="#909BCB" stroke-opacity="0.26" stroke-linecap="round"/>
+</svg>

--- a/apps/sdk-explorer/src/images/MoviesByActor.svg
+++ b/apps/sdk-explorer/src/images/MoviesByActor.svg
@@ -1,0 +1,803 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="200" height="200" fill="white"/>
+<mask id="mask0_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="45" width="35" height="35">
+<path d="M45 45H10L45 80V45Z" fill="#D1D8F6"/>
+</mask>
+<g mask="url(#mask0_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -118 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -114.301 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -110.603 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -106.904 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -103.205 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -99.5069 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -95.8082 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.1096 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.411 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.7123 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.0137 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.3151 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.6164 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -69.9178 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.2192 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.5206 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -58.8219 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.1233 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.4247 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.726 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.0274 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.3288 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.6301 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.9315 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.2329 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.5342 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.8356 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.137 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.4384 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.7397 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.04111 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.34247 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.356171 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.05481 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.75342 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.4521 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.1507 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.8493 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.5479 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.2466 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.9452 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.6438 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.3425 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.0411 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.7397 167)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask1_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="120" y="45" width="35" height="35">
+<path d="M155 45H120L155 80V45Z" fill="#D1D8F6"/>
+</mask>
+<g mask="url(#mask1_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -8 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -4.30138 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -0.602737 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.09589 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 6.79453 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10.4931 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.1918 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 17.8904 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.589 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 25.2877 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28.9863 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.6849 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 36.3836 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.0822 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 43.7808 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47.4794 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.1781 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.8767 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.5753 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 62.274 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.9726 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.6712 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 73.3699 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 77.0685 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.7671 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 84.4658 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 88.1644 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.863 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.5616 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 99.2603 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.959 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.658 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 110.356 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 114.055 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.753 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 121.452 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 125.151 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 128.849 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 132.548 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 136.247 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 139.945 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 143.644 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 147.342 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 151.041 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 154.74 167)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask2_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="45" y="45" width="35" height="35">
+<path d="M45 45H80L45 80V45Z" fill="#D1D8F6"/>
+</mask>
+<g mask="url(#mask2_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 208 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 204.301 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 200.603 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 196.904 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 193.205 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 189.507 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 185.808 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 182.11 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 178.411 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 174.712 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 171.014 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 167.315 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 163.616 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 159.918 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 156.219 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 152.521 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 148.822 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 145.123 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 141.425 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 137.726 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 134.027 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 130.329 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 126.63 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 122.932 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 119.233 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 115.534 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 111.836 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 108.137 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 104.438 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 100.74 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 97.0411 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 93.3425 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 89.6438 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 85.9452 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 82.2466 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 78.5479 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 74.8493 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 71.1507 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 67.4521 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 63.7534 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 60.0548 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 56.3562 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 52.6575 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 48.9589 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 45.2603 167)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask3_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="155" y="45" width="35" height="35">
+<path d="M155 45H190L155 80V45Z" fill="#D1D8F6"/>
+</mask>
+<g mask="url(#mask3_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 318 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 314.301 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 310.603 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 306.904 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 303.205 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 299.507 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 295.808 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 292.11 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 288.411 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 284.712 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 281.014 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 277.315 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 273.616 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 269.918 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 266.219 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 262.521 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 258.822 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 255.123 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 251.425 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 247.726 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 244.027 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 240.329 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 236.63 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 232.932 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 229.233 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 225.534 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 221.836 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 218.137 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 214.438 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 210.74 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 207.041 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 203.342 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 199.644 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 195.945 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 192.247 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 188.548 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 184.849 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 181.151 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 177.452 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 173.753 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 170.055 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 166.356 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 162.658 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 158.959 167)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(-0.707711 -0.706502 -0.707711 0.706502 155.26 167)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask4_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="10" width="35" height="35">
+<path d="M45 45H10L45 10V45Z" fill="#D1D8F6"/>
+</mask>
+<g mask="url(#mask4_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -118 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -114.301 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -110.603 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -106.904 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -103.205 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -99.5069 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -95.8082 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -92.1096 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -88.411 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -84.7123 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -81.0137 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -77.3151 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -73.6164 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -69.9178 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -66.2192 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -62.5206 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -58.8219 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -55.1233 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -51.4247 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -47.726 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -44.0274 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -40.3288 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -36.6301 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -32.9315 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -29.2329 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -25.5342 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -21.8356 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -18.137 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -14.4384 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -10.7397 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -7.04111 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -3.34247 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 0.356171 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 4.05481 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 7.75342 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 11.4521 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 15.1507 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 18.8493 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 22.5479 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 26.2466 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 29.9452 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 33.6438 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 37.3425 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 41.0411 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 44.7397 -77)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask5_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="120" y="10" width="35" height="35">
+<path d="M155 45H120L155 10V45Z" fill="#D1D8F6"/>
+</mask>
+<g mask="url(#mask5_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -8 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -4.30138 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 -0.602737 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 3.09589 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 6.79453 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 10.4931 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 14.1918 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 17.8904 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 21.589 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 25.2877 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 28.9863 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 32.6849 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 36.3836 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 40.0822 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 43.7808 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 47.4794 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 51.1781 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 54.8767 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 58.5753 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 62.274 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 65.9726 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 69.6712 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 73.3699 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 77.0685 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 80.7671 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 84.4658 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 88.1644 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 91.863 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 95.5616 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 99.2603 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 102.959 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 106.658 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 110.356 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 114.055 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 117.753 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 121.452 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 125.151 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 128.849 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 132.548 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 136.247 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 139.945 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 143.644 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 147.342 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 151.041 -77)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 0.706502 0.707711 -0.706502 154.74 -77)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask6_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="100" width="74" height="8">
+<rect x="10" y="100" width="74" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask6_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -96 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.3014 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.6027 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.9041 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.2055 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.5069 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.8082 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.1096 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.411 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.7123 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.0137 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.3151 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.6164 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.9178 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.2192 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.5206 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.8219 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.1233 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.4247 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.726 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.0274 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.3288 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.6301 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.9315 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.23288 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.53424 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.164383 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.86301 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.56165 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.2603 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.9589 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.6575 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.3562 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.0548 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.7534 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.4521 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.1507 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.8493 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.5479 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.2466 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.9452 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.6438 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.3425 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.0411 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.7397 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.4384 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.137 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 77.8356 203)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.5343 203)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask7_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="116" y="102" width="74" height="8">
+<rect x="116" y="102" width="74" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask7_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 13.6986 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 17.3973 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.0959 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 24.7945 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28.4931 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.1918 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 35.8904 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.589 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 43.2877 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 46.9863 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.6849 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.3836 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.0822 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.7808 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.4794 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.1781 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.8767 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.5753 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.274 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.9726 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.6712 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.3699 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.0685 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.7671 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.466 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.164 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.863 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.562 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.26 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.959 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.658 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 128.356 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 132.055 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.753 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 139.452 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 143.151 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.849 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.548 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 154.247 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.945 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.644 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 165.342 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 169.041 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.74 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 176.438 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 180.137 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 183.836 205)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 187.534 205)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask8_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="132" width="74" height="8">
+<rect x="10" y="132" width="74" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask8_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -96 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.3014 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.6027 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.9041 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.2055 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.5069 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.8082 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.1096 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.411 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.7123 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.0137 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.3151 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.6164 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.9178 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.2192 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.5206 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.8219 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.1233 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.4247 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.726 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.0274 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.3288 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.6301 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.9315 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.23288 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.53424 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.164383 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.86301 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.56165 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.2603 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.9589 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.6575 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.3562 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.0548 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.7534 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.4521 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.1507 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.8493 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.5479 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.2466 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.9452 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.6438 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.3425 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.0411 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.7397 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.4384 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.137 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 77.8356 235)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.5343 235)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask9_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="116" y="134" width="74" height="8">
+<rect x="116" y="134" width="74" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask9_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 13.6986 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 17.3973 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.0959 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 24.7945 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28.4931 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.1918 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 35.8904 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.589 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 43.2877 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 46.9863 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.6849 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.3836 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.0822 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.7808 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.4794 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.1781 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.8767 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.5753 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.274 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.9726 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.6712 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.3699 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.0685 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.7671 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.466 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.164 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.863 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.562 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.26 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.959 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.658 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 128.356 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 132.055 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.753 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 139.452 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 143.151 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.849 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.548 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 154.247 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.945 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.644 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 165.342 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 169.041 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.74 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 176.438 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 180.137 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 183.836 237)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 187.534 237)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask10_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="164" width="74" height="8">
+<rect x="10" y="164" width="74" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask10_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -96 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.3014 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.6027 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.9041 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.2055 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.5069 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.8082 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.1096 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.411 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.7123 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.0137 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.3151 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.6164 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.9178 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.2192 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.5206 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.8219 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.1233 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.4247 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.726 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.0274 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.3288 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.6301 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.9315 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.23288 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.53424 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.164383 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.86301 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.56165 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.2603 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.9589 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.6575 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.3562 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.0548 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.7534 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.4521 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.1507 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.8493 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.5479 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.2466 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.9452 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.6438 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.3425 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.0411 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.7397 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.4384 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.137 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 77.8356 267)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.5343 267)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask11_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="116" width="45" height="8">
+<rect x="10" y="116" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask11_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -96 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.3014 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.6027 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.9041 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.2055 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.5069 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.8082 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.1096 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.411 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.7123 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.0137 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.3151 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.6164 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.9178 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.2192 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.5206 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.8219 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.1233 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.4247 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.726 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.0274 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.3288 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.6301 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.9315 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.23288 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.53424 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.164383 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.86301 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.56165 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.2603 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.9589 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.6575 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.3562 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.0548 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.7534 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.4521 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.1507 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.8493 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.5479 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.2466 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.9452 219)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask12_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="116" y="118" width="45" height="8">
+<rect x="116" y="118" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask12_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 13.6986 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 17.3973 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.0959 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 24.7945 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28.4931 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.1918 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 35.8904 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.589 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 43.2877 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 46.9863 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.6849 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.3836 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.0822 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.7808 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.4794 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.1781 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.8767 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.5753 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.274 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.9726 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.6712 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.3699 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.0685 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.7671 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.466 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.164 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.863 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.562 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.26 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.959 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.658 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 128.356 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 132.055 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.753 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 139.452 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 143.151 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.849 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.548 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 154.247 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.945 221)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask13_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="148" width="45" height="8">
+<rect x="10" y="148" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask13_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -96 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.3014 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.6027 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.9041 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.2055 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.5069 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.8082 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.1096 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.411 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.7123 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.0137 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.3151 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.6164 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.9178 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.2192 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.5206 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.8219 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.1233 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.4247 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.726 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.0274 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.3288 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.6301 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.9315 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.23288 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.53424 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.164383 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.86301 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.56165 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.2603 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.9589 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.6575 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.3562 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.0548 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.7534 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.4521 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.1507 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.8493 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.5479 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.2466 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.9452 251)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask14_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="116" y="150" width="45" height="8">
+<rect x="116" y="150" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask14_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 13.6986 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 17.3973 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.0959 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 24.7945 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28.4931 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.1918 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 35.8904 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.589 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 43.2877 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 46.9863 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.6849 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.3836 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.0822 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.7808 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.4794 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.1781 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.8767 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.5753 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.274 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.9726 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.6712 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.3699 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.0685 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.7671 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.466 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.164 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.863 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.562 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.26 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.959 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.658 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 128.356 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 132.055 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.753 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 139.452 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 143.151 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.849 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.548 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 154.247 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.945 253)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask15_17_3899" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="180" width="45" height="8">
+<rect x="10" y="180" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask15_17_3899)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -96 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.3014 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.6027 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.9041 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.2055 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.5069 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.8082 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.1096 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.411 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.7123 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.0137 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.3151 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.6164 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.9178 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.2192 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.5206 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.8219 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.1233 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.4247 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.726 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.0274 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.3288 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.6301 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.9315 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.23288 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.53424 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.164383 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.86301 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.56165 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.2603 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.9589 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.6575 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.3562 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.0548 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.7534 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.4521 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.1507 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.8493 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.5479 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.2466 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.9452 283)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+</svg>

--- a/apps/sdk-explorer/src/images/PreviewGrid.svg
+++ b/apps/sdk-explorer/src/images/PreviewGrid.svg
@@ -1,0 +1,927 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="200" height="200" fill="white"/>
+<mask id="mask0_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="10" width="56" height="56">
+<rect x="10" y="10" width="56" height="56" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -132.438 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -128.74 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -125.041 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -121.342 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -117.644 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -113.945 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -110.247 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -106.548 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -102.849 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -99.1507 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -95.4521 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -91.7534 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.0548 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.3562 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -80.6575 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -76.9589 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.2603 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -69.5616 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -65.863 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.1644 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -58.4657 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -54.7671 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.0685 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.3699 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -43.6712 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -39.9726 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.274 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.5753 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -28.8767 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.1781 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.4794 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -17.7808 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.0822 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.3835 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -6.68492 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -2.9863 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.712326 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.41095 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 8.1096 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.8082 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.5069 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.2055 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.9041 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.6028 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.3014 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.6986 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.3972 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.0959 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.7945 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.4932 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 56.1918 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.8904 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.5891 116)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask1_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="74" width="54" height="8">
+<rect x="10" y="74" width="54" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask1_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -96 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.3014 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.6027 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.9041 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.2055 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.5069 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.8082 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.1096 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.411 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.7123 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.0137 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.3151 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.6164 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.9178 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.2192 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.5206 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.8219 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.1233 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.4247 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.726 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.0274 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.3288 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.6301 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.9315 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.23287 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.53425 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.164383 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.86301 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.56165 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.2603 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.9589 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.6575 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.3562 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.0548 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.7534 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.4521 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.1507 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.8493 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.5479 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.2466 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.9452 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.6438 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.3425 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.0411 177)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask2_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="86" width="45" height="8">
+<rect x="10" y="86" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask2_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -96 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.3014 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.6027 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.9041 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.2055 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.5069 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.8082 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.1096 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.411 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.7123 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.0137 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.3151 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.6164 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.9178 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.2192 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.5206 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.8219 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.1233 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.4247 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.726 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.0274 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.3288 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.6301 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.9315 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.23287 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.53425 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.164383 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.86301 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.56165 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.2603 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.9589 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.6575 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.3562 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.0548 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.7534 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.4521 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.1507 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.8493 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.5479 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.2466 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.9452 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask3_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="106" width="56" height="56">
+<rect x="10" y="106" width="56" height="56" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask3_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -132.438 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -128.74 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -125.041 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -121.342 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -117.644 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -113.945 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -110.247 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -106.548 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -102.849 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -99.1507 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -95.4521 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -91.7534 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.0548 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.3562 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -80.6575 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -76.9589 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.2603 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -69.5616 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -65.863 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.1644 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -58.4657 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -54.7671 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.0685 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.3699 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -43.6712 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -39.9726 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.274 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.5753 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -28.8767 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.1781 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.4794 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -17.7808 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.0822 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.3835 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -6.68492 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -2.9863 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.712326 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.41095 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 8.1096 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.8082 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.5069 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.2055 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.9041 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.6028 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.3014 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.6986 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.3972 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.0959 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.7945 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.4932 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 56.1918 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.8904 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.5891 212)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask4_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="170" width="54" height="8">
+<rect x="10" y="170" width="54" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask4_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -96 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.3014 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.6027 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.9041 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.2055 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.5069 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.8082 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.1096 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.411 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.7123 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.0137 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.3151 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.6164 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.9178 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.2192 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.5206 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.8219 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.1233 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.4247 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.726 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.0274 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.3288 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.6301 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.9315 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.23287 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.53425 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.164383 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.86301 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.56165 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.2603 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.9589 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.6575 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.3562 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.0548 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.7534 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.4521 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.1507 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.8493 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.5479 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.2466 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.9452 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.6438 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.3425 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.0411 273)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask5_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="182" width="45" height="8">
+<rect x="10" y="182" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask5_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -96 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -92.3014 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.6027 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.9041 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -81.2055 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -77.5069 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.8082 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.1096 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.411 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.7123 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.0137 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.3151 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.6164 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.9178 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.2192 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.5206 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.8219 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.1233 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.4247 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.726 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.0274 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.3288 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.6301 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.9315 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.23287 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.53425 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.164383 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.86301 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.56165 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.2603 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.9589 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.6575 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.3562 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.0548 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.7534 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.4521 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.1507 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.8493 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.5479 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.2466 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.9452 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask6_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="72" y="10" width="56" height="56">
+<rect x="72" y="10" width="56" height="56" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask6_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.4384 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.7397 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -63.0411 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.3425 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.6438 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.9452 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -48.2466 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.5479 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.8493 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -37.1507 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.4521 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.7534 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -26.0548 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.3562 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.6575 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.9589 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -11.2603 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.56165 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.86302 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -0.164383 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.53426 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.23288 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10.9315 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.6301 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.3288 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.0274 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 25.726 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.4247 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.1233 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 36.8219 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.5206 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.2192 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47.9178 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.6165 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.3151 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.0137 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 62.7123 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.4109 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.1096 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 73.8082 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 77.5069 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.2055 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 84.9041 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 88.6028 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.3014 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 96 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 99.6986 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 103.397 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 107.096 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 110.795 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 114.493 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 118.192 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 121.89 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 125.589 116)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask7_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="72" y="74" width="54" height="8">
+<rect x="72" y="74" width="54" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask7_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -34 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -30.3014 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -26.6027 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.9041 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -19.2055 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -15.5069 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -11.8082 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -8.10959 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -4.41096 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -0.71233 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 2.9863 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 6.68493 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10.3836 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.0822 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 17.7808 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.4795 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 25.1781 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28.8767 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.5753 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 36.274 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.9726 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 43.6712 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47.3699 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.0685 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.7671 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.4658 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 62.1644 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.863 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.5616 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 73.2603 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.9589 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.6575 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 84.3562 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 88.0548 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.7534 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.4521 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 99.1507 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.849 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.548 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 110.247 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.945 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.644 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 121.342 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 125.041 177)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask8_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="72" y="86" width="45" height="8">
+<rect x="72" y="86" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask8_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -34 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -30.3014 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -26.6027 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.9041 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -19.2055 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -15.5069 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -11.8082 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -8.10959 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -4.41096 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -0.71233 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 2.9863 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 6.68493 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10.3836 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.0822 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 17.7808 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.4795 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 25.1781 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28.8767 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.5753 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 36.274 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.9726 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 43.6712 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47.3699 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.0685 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.7671 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.4658 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 62.1644 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.863 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.5616 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 73.2603 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.9589 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.6575 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 84.3562 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 88.0548 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.7534 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.4521 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 99.1507 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.849 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.548 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 110.247 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.945 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask9_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="72" y="106" width="56" height="56">
+<rect x="72" y="106" width="56" height="56" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask9_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -70.4384 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -66.7397 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -63.0411 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -59.3425 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -55.6438 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.9452 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -48.2466 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44.5479 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.8493 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -37.1507 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -33.4521 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.7534 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -26.0548 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.3562 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.6575 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.9589 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -11.2603 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.56165 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.86302 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -0.164383 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 3.53426 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.23288 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10.9315 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.6301 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.3288 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.0274 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 25.726 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.4247 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.1233 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 36.8219 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 40.5206 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.2192 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47.9178 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.6165 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.3151 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.0137 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 62.7123 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.4109 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.1096 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 73.8082 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 77.5069 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.2055 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 84.9041 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 88.6028 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.3014 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 96 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 99.6986 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 103.397 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 107.096 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 110.795 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 114.493 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 118.192 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 121.89 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 125.589 212)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask10_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="72" y="170" width="54" height="8">
+<rect x="72" y="170" width="54" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask10_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -34 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -30.3014 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -26.6027 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.9041 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -19.2055 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -15.5069 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -11.8082 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -8.10959 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -4.41096 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -0.71233 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 2.9863 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 6.68493 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10.3836 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.0822 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 17.7808 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.4795 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 25.1781 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28.8767 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.5753 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 36.274 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.9726 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 43.6712 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47.3699 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.0685 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.7671 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.4658 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 62.1644 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.863 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.5616 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 73.2603 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.9589 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.6575 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 84.3562 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 88.0548 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.7534 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.4521 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 99.1507 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.849 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.548 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 110.247 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.945 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.644 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 121.342 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 125.041 273)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask11_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="72" y="182" width="45" height="8">
+<rect x="72" y="182" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask11_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -34 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -30.3014 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -26.6027 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -22.9041 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -19.2055 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -15.5069 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -11.8082 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -8.10959 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -4.41096 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -0.71233 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 2.9863 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 6.68493 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10.3836 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 14.0822 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 17.7808 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.4795 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 25.1781 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28.8767 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.5753 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 36.274 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.9726 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 43.6712 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47.3699 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 51.0685 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.7671 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.4658 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 62.1644 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.863 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.5616 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 73.2603 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.9589 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.6575 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 84.3562 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 88.0548 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.7534 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.4521 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 99.1507 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.849 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.548 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 110.247 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.945 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask12_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="134" y="10" width="56" height="56">
+<rect x="134" y="10" width="56" height="56" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask12_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -8.43835 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -4.73972 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -1.0411 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 2.65754 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 6.35616 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10.0548 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 13.7534 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 17.4521 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.1507 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 24.8493 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28.5479 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.2466 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 35.9452 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.6438 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 43.3425 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47.0411 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.7397 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.4384 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.137 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.8356 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.5343 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.2329 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.9315 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.6301 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.3288 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 84.0274 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.726 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.4247 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.1233 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.8219 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.521 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.219 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.918 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.616 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.315 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 121.014 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.712 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 128.411 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 132.11 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.808 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 139.507 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 143.205 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.904 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.603 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 154.301 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 158 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.699 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 165.397 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 169.096 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.795 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 176.493 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 180.192 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 183.89 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 187.589 116)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask13_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="134" y="74" width="54" height="8">
+<rect x="134" y="74" width="54" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask13_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 31.6986 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 35.3973 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.0959 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 42.7945 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 46.4932 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.1918 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 53.8904 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 57.589 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.2877 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 64.9863 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 68.6849 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.3836 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.0822 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 79.7808 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.4795 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.1781 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 90.8767 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 94.5753 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.274 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 101.973 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 105.671 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.37 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.068 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 116.767 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.466 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.164 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 127.863 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 131.562 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.26 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 138.959 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 142.658 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.356 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.055 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 153.753 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.452 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.151 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 164.849 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 168.548 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.247 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 175.945 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 179.644 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 183.342 177)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 187.041 177)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask14_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="134" y="86" width="45" height="8">
+<rect x="134" y="86" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask14_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 31.6986 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 35.3973 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.0959 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 42.7945 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 46.4932 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.1918 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 53.8904 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 57.589 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.2877 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 64.9863 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 68.6849 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.3836 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.0822 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 79.7808 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.4795 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.1781 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 90.8767 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 94.5753 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.274 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 101.973 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 105.671 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.37 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.068 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 116.767 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.466 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.164 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 127.863 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 131.562 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.26 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 138.959 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 142.658 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.356 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.055 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 153.753 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.452 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.151 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 164.849 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 168.548 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.247 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 175.945 189)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask15_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="134" y="106" width="56" height="56">
+<rect x="134" y="106" width="56" height="56" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask15_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -8.43835 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -4.73972 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -1.0411 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 2.65754 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 6.35616 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 10.0548 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 13.7534 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 17.4521 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 21.1507 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 24.8493 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28.5479 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 32.2466 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 35.9452 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.6438 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 43.3425 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 47.0411 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.7397 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 54.4384 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 58.137 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.8356 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 65.5343 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 69.2329 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.9315 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.6301 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 80.3288 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 84.0274 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.726 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 91.4247 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 95.1233 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.8219 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 102.521 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 106.219 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.918 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.616 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 117.315 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 121.014 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.712 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 128.411 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 132.11 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.808 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 139.507 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 143.205 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.904 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.603 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 154.301 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 158 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.699 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 165.397 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 169.096 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.795 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 176.493 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 180.192 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 183.89 212)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 187.589 212)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask16_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="134" y="170" width="54" height="8">
+<rect x="134" y="170" width="54" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask16_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 31.6986 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 35.3973 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.0959 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 42.7945 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 46.4932 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.1918 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 53.8904 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 57.589 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.2877 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 64.9863 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 68.6849 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.3836 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.0822 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 79.7808 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.4795 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.1781 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 90.8767 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 94.5753 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.274 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 101.973 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 105.671 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.37 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.068 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 116.767 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.466 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.164 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 127.863 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 131.562 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.26 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 138.959 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 142.658 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.356 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.055 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 153.753 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.452 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.151 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 164.849 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 168.548 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.247 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 175.945 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 179.644 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 183.342 273)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 187.041 273)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask17_17_5676" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="134" y="182" width="45" height="8">
+<rect x="134" y="182" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask17_17_5676)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 28 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 31.6986 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 35.3973 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 39.0959 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 42.7945 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 46.4932 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 50.1918 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 53.8904 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 57.589 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 61.2877 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 64.9863 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 68.6849 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 72.3836 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 76.0822 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 79.7808 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 83.4795 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 87.1781 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 90.8767 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 94.5753 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 98.274 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 101.973 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 105.671 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 109.37 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 113.068 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 116.767 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 120.466 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 124.164 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 127.863 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 131.562 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 135.26 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 138.959 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 142.658 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 146.356 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 150.055 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 153.753 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 157.452 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 161.151 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 164.849 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 168.548 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 172.247 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 175.945 285)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+</svg>

--- a/apps/sdk-explorer/src/images/PreviewList.svg
+++ b/apps/sdk-explorer/src/images/PreviewList.svg
@@ -1,0 +1,465 @@
+<svg width="200" height="200" viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="200" height="200" fill="white"/>
+<mask id="mask0_17_10682" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="10" width="42" height="54">
+<rect x="10" y="10" width="42" height="54" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask0_17_10682)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -132.438 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -128.74 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -125.041 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -121.342 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -117.644 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -113.945 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -110.247 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -106.548 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -102.849 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -99.1507 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -95.4521 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -91.7534 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.0548 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.3561 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -80.6575 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -76.9589 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.2603 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -69.5616 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -65.863 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.1644 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -58.4658 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -54.7671 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.0685 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.3699 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -43.6712 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -39.9726 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.274 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.5753 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -28.8767 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.1781 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.4794 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -17.7808 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.0822 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.3835 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -6.68494 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -2.9863 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.712341 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.41095 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 8.10962 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.8082 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.5068 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.2055 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.9041 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.6028 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.3014 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.6986 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.3972 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.0959 116)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.7945 116)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask1_17_10682" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="62" y="27" width="68" height="8">
+<rect x="62" y="27" width="68" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask1_17_10682)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.3014 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.6028 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.9041 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.2055 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.5068 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.8082 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.1096 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.4109 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.7123 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.0137 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.31506 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.383575 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.08218 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.78082 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.4795 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.1781 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.8767 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.5753 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.274 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.9726 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.6712 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.3699 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.0685 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.7671 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.4658 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.1644 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.863 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.5616 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.2603 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.9589 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.6575 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.3562 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.0548 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.7534 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.4521 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.1507 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.8493 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 96.5479 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.247 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 103.945 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 107.644 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 111.342 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 115.041 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 118.74 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 122.438 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 126.137 130)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 129.836 130)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask2_17_10682" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="62" y="39" width="45" height="8">
+<rect x="62" y="39" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask2_17_10682)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.3014 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.6028 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.9041 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.2055 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.5068 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.8082 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.1096 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.4109 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.7123 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.0137 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.31506 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.383575 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.08218 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.78082 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.4795 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.1781 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.8767 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.5753 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.274 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.9726 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.6712 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.3699 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.0685 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.7671 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.4658 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.1644 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.863 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.5616 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.2603 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.9589 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.6575 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.3562 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.0548 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.7534 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.4521 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.1507 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.8493 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 96.5479 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.247 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 103.945 142)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask3_17_10682" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="73" width="42" height="54">
+<rect x="10" y="73" width="42" height="54" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask3_17_10682)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -132.438 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -128.74 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -125.041 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -121.342 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -117.644 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -113.945 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -110.247 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -106.548 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -102.849 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -99.1507 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -95.4521 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -91.7534 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.0548 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.3561 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -80.6575 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -76.9589 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.2603 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -69.5616 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -65.863 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.1644 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -58.4658 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -54.7671 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.0685 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.3699 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -43.6712 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -39.9726 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.274 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.5753 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -28.8767 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.1781 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.4794 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -17.7808 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.0822 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.3835 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -6.68494 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -2.9863 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.712341 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.41095 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 8.10962 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.8082 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.5068 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.2055 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.9041 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.6028 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.3014 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.6986 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.3972 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.0959 179)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.7945 179)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask4_17_10682" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="62" y="90" width="68" height="8">
+<rect x="62" y="90" width="68" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask4_17_10682)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.3014 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.6028 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.9041 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.2055 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.5068 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.8082 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.1096 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.4109 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.7123 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.0137 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.31506 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.383575 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.08218 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.78082 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.4795 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.1781 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.8767 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.5753 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.274 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.9726 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.6712 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.3699 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.0685 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.7671 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.4658 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.1644 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.863 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.5616 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.2603 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.9589 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.6575 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.3562 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.0548 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.7534 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.4521 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.1507 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.8493 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 96.5479 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.247 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 103.945 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 107.644 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 111.342 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 115.041 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 118.74 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 122.438 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 126.137 193)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 129.836 193)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask5_17_10682" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="62" y="102" width="45" height="8">
+<rect x="62" y="102" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask5_17_10682)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.3014 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.6028 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.9041 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.2055 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.5068 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.8082 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.1096 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.4109 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.7123 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.0137 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.31506 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.383575 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.08218 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.78082 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.4795 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.1781 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.8767 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.5753 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.274 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.9726 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.6712 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.3699 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.0685 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.7671 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.4658 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.1644 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.863 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.5616 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.2603 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.9589 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.6575 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.3562 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.0548 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.7534 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.4521 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.1507 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.8493 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 96.5479 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.247 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 103.945 205)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+<mask id="mask6_17_10682" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="10" y="136" width="42" height="54">
+<rect x="10" y="136" width="42" height="54" rx="6" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask6_17_10682)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -132.438 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -128.74 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -125.041 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -121.342 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -117.644 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -113.945 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -110.247 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -106.548 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -102.849 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -99.1507 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -95.4521 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -91.7534 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -88.0548 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -84.3561 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -80.6575 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -76.9589 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -73.2603 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -69.5616 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -65.863 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -62.1644 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -58.4658 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -54.7671 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -51.0685 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -47.3699 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -43.6712 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -39.9726 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.274 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.5753 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -28.8767 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.1781 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.4794 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -17.7808 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.0822 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.3835 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -6.68494 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -2.9863 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.712341 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.41095 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 8.10962 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.8082 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.5068 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 19.2055 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.9041 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.6028 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 30.3014 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 34 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.6986 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.3972 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 45.0959 242)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.7945 242)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask7_17_10682" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="62" y="153" width="68" height="8">
+<rect x="62" y="153" width="68" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask7_17_10682)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.3014 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.6028 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.9041 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.2055 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.5068 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.8082 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.1096 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.4109 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.7123 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.0137 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.31506 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.383575 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.08218 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.78082 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.4795 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.1781 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.8767 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.5753 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.274 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.9726 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.6712 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.3699 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.0685 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.7671 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.4658 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.1644 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.863 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.5616 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.2603 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.9589 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.6575 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.3562 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.0548 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.7534 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.4521 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.1507 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.8493 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 96.5479 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.247 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 103.945 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 107.644 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 111.342 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 115.041 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 118.74 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 122.438 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 126.137 256)" stroke="#909BCB" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 129.836 256)" stroke="#909BCB" stroke-width="0.66"/>
+</g>
+<mask id="mask8_17_10682" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="62" y="165" width="45" height="8">
+<rect x="62" y="165" width="45" height="8" rx="4" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#mask8_17_10682)">
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -44 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -40.3014 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -36.6028 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -32.9041 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -29.2055 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -25.5068 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -21.8082 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -18.1096 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -14.4109 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -10.7123 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -7.0137 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 -3.31506 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 0.383575 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 4.08218 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 7.78082 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 11.4795 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 15.1781 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 18.8767 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 22.5753 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 26.274 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 29.9726 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 33.6712 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 37.3699 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 41.0685 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 44.7671 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 48.4658 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 52.1644 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 55.863 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 59.5616 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 63.2603 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 66.9589 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 70.6575 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 74.3562 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 78.0548 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 81.7534 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 85.4521 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 89.1507 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 92.8493 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 96.5479 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 100.247 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+<line y1="-0.33" x2="203.821" y2="-0.33" transform="matrix(0.707711 -0.706502 0.707711 0.706502 103.945 268)" stroke="#909BCB" stroke-opacity="0.5" stroke-width="0.66"/>
+</g>
+</svg>


### PR DESCRIPTION
## Description

This PR updates the general look and feel of the SDK Explorer to more closely adhere to the general Sanity design language. This has been implemented based on feedback from the design team.

In brief:

- Site header now full width (not inset)
- Added extra SDK links to site header
- Example cards made to look more clickable
- Added 'skeleton' visuals to each example card
- More clearly delineated example content from example metadata on example pages
- Added summaries of each example on example pages
- General colour palette and layout updates to hew more closely to [the new Sanity docs site design](https://sanity-docs.sanity.build/docs/app-sdk)

## What to review

⚠️ **Note:** I have not yet updated the version of the SDK used in this app. There will be a separate PR for doing that coming later, as some hook implementations are still in flux. Thus you're going to see old hook names in this PR still. ;)

Otherwise, it's mostly just markup! 💁🏻‍♂️ 

## Testing

N/A, but you can [refer to the preview deployment if you'd like to see it in action](https://sdk-examples-git-feat-design-updates.sanity.dev/)!

## Fun gif

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWIwdmd5bTcycjMwMGJjenVkZmpiZnN5N2Q3amFrOHA0MmlrZ3VydSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/DkPAMnIvKf040/giphy.gif)